### PR TITLE
Fix SVQ download

### DIFF
--- a/com.makemkv.MakeMKV.json
+++ b/com.makemkv.MakeMKV.json
@@ -43,8 +43,8 @@
         "sources": [
             {
                 "type": "archive",
-                "url": "https://ftp.gnu.org/gnu/wget/wget-1.20.3.tar.lz",
-                "sha256": "69607ce8216c2d1126b7a872db594b3f21e511e660e07ca1f81be96650932abb"
+                "url": "https://ftp.gnu.org/gnu/wget/wget-1.20.3.tar.gz",
+                "sha256": "31cccfc6630528db1c8e3a06f6decf2a370060b982841cfab2b8677400a5092e"
             }
         ]
     },

--- a/com.makemkv.MakeMKV.json
+++ b/com.makemkv.MakeMKV.json
@@ -38,6 +38,17 @@
         ]
     },
     {
+        "name": "wget",
+        "no-autogen": true,
+        "sources": [
+            {
+                "type": "archive",
+                "url": "https://ftp.gnu.org/gnu/wget/wget-1.20.3.tar.lz",
+                "sha256": "69607ce8216c2d1126b7a872db594b3f21e511e660e07ca1f81be96650932abb"
+            }
+        ]
+    },
+    {
       "name": "x264",
       "config-opts": [
         "--disable-cli",
@@ -112,6 +123,10 @@
           "type": "archive",
           "url": "http://www.makemkv.com/download/makemkv-oss-1.14.3.tar.gz",
           "sha256": "222cf2dcfde7a84944353c7edd326e18e3d35b7a7e575484111f64a4b1b9fec9"
+        },
+        {
+            "type": "patch",
+            "path": "patch/makemkv-oss-wget.patch"
         },
         {
           "type": "file",

--- a/patch/makemkv-oss-wget.patch
+++ b/patch/makemkv-oss-wget.patch
@@ -1,6 +1,6 @@
 diff -ur makemkv-oss-1.14.4.orig/libabi/src/httplinux.cpp makemkv-oss-1.14.4/libabi/src/httplinux.cpp
 --- makemkv-oss-1.14.4.orig/libabi/src/httplinux.cpp	2019-06-07 09:39:20.000000000 -0700
-+++ makemkv-oss-1.14.4/libabi/src/httplinux.cpp	2019-06-12 09:04:31.294677822 -0700
++++ makemkv-oss-1.14.4/libabi/src/httplinux.cpp	2019-07-10 11:18:02.282636795 -0700
 @@ -47,7 +47,7 @@
      lurl = (char*)alloca(strlen(Url)+1);
      strcpy(lurl,Url);
@@ -12,16 +12,13 @@ diff -ur makemkv-oss-1.14.4.orig/libabi/src/httplinux.cpp makemkv-oss-1.14.4/lib
      strcpy(argv3,"-"); argv[3]=argv3;
 diff -ur makemkv-oss-1.14.4.orig/makemkvgui/src/spawn_posix.cpp makemkv-oss-1.14.4/makemkvgui/src/spawn_posix.cpp
 --- makemkv-oss-1.14.4.orig/makemkvgui/src/spawn_posix.cpp	2019-06-07 09:39:20.000000000 -0700
-+++ makemkv-oss-1.14.4/makemkvgui/src/spawn_posix.cpp	2019-06-12 09:03:36.862712866 -0700
-@@ -75,7 +75,10 @@
++++ makemkv-oss-1.14.4/makemkvgui/src/spawn_posix.cpp	2019-07-10 11:18:28.821103602 -0700
+@@ -75,7 +75,7 @@
          }
      }
  
 -    err = posix_spawn(&pid,argv[0],&spawn_actions,&spawn_attr,argv,envp);
-+    if (argv && argv[0] && argv[0][0] != '/')
-+        err = posix_spawnp(&pid,argv[0],&spawn_actions,&spawn_attr,argv,envp);
-+    else
-+        err = posix_spawn(&pid,argv[0],&spawn_actions,&spawn_attr,argv,envp);
++    err = posix_spawnp(&pid,argv[0],&spawn_actions,&spawn_attr,argv,envp);
  
      if (ppid)
      {

--- a/patch/makemkv-oss-wget.patch
+++ b/patch/makemkv-oss-wget.patch
@@ -1,0 +1,27 @@
+diff -ur makemkv-oss-1.14.4.orig/libabi/src/httplinux.cpp makemkv-oss-1.14.4/libabi/src/httplinux.cpp
+--- makemkv-oss-1.14.4.orig/libabi/src/httplinux.cpp	2019-06-07 09:39:20.000000000 -0700
++++ makemkv-oss-1.14.4/libabi/src/httplinux.cpp	2019-06-12 09:04:31.294677822 -0700
+@@ -47,7 +47,7 @@
+     lurl = (char*)alloca(strlen(Url)+1);
+     strcpy(lurl,Url);
+ 
+-    strcpy(argv0,"/usr/bin/wget"); argv[0]=argv0;
++    strcpy(argv0,"wget"); argv[0]=argv0;
+     strcpy(argv1,"-q"); argv[1]=argv1;
+     strcpy(argv2,"-O"); argv[2]=argv2;
+     strcpy(argv3,"-"); argv[3]=argv3;
+diff -ur makemkv-oss-1.14.4.orig/makemkvgui/src/spawn_posix.cpp makemkv-oss-1.14.4/makemkvgui/src/spawn_posix.cpp
+--- makemkv-oss-1.14.4.orig/makemkvgui/src/spawn_posix.cpp	2019-06-07 09:39:20.000000000 -0700
++++ makemkv-oss-1.14.4/makemkvgui/src/spawn_posix.cpp	2019-06-12 09:03:36.862712866 -0700
+@@ -75,7 +75,10 @@
+         }
+     }
+ 
+-    err = posix_spawn(&pid,argv[0],&spawn_actions,&spawn_attr,argv,envp);
++    if (argv && argv[0] && argv[0][0] != '/')
++        err = posix_spawnp(&pid,argv[0],&spawn_actions,&spawn_attr,argv,envp);
++    else
++        err = posix_spawn(&pid,argv[0],&spawn_actions,&spawn_attr,argv,envp);
+ 
+     if (ppid)
+     {


### PR DESCRIPTION
Allows SVQ downloads and fixes log message ```Automatic SVQ downloading is disabled or failed```

SVQ download requires wget which the kde flatpak runtime does not provide.
Also, makemkv hardcodes the path to /usr/bin/wget.  So patch makemkv to use ```$PATH```

SVQ files are required for some BD+ discs, see https://www.makemkv.com/svq/