### PR TITLE
Use OpenJDK8 instead of OpenJDK.

### DIFF
--- a/com.makemkv.MakeMKV.json
+++ b/com.makemkv.MakeMKV.json
@@ -5,7 +5,7 @@
   "sdk": "org.kde.Sdk",
   /* NOTE: java is optional to help find blu-ray main titles */
   "sdk-extensions": [
-    "org.freedesktop.Sdk.Extension.openjdk"
+    "org.freedesktop.Sdk.Extension.openjdk8"
   ],
   "finish-args": [
     "--filesystem=host",
@@ -20,7 +20,7 @@
   ],
   "command": "makemkv",
   "build-options" : {
-    "append-path": "/usr/lib/sdk/openjdk/bin"
+    "append-path": "/usr/lib/sdk/openjdk8/bin"
   },
   "rename-desktop-file": "makemkv.desktop",
   "rename-icon": "makemkv",
@@ -34,7 +34,7 @@
       "name": "openjdk",
         "buildsystem": "simple",
         "build-commands": [
-          "/usr/lib/sdk/openjdk/install.sh"
+          "/usr/lib/sdk/openjdk8/install.sh"
         ]
     },
     {


### PR DESCRIPTION
- Be explicit about which OpenJDK version is known to work with MakeMKV.
- Currently MakeMKV is bundled with a version libbluray that apparently only
  integrates with JRE8.
- This was previously fixed in PR #26
- The issue appears to return in PR #29

To reproduce the issue:
* You must have source material that triggers libbluray BD-j sandbox.
* You can read more about the feature here: https://forum.makemkv.com/forum/viewtopic.php?f=8&t=14330
* and here: http://www.makemkv.com/bdjava/
* Run the flatpak
* Make sure via MakeMKV gui has debug logging enabled.
* Load an obfuscated bd-j in MakeMKV.
* The logging panel should not indicate any java issues.
* There should be no "java.lang.NullPointerException".
* Nor should there be any logs indicating missing java:
```
MakeMKV v1.16.5 linux(x64-release) started
Debug logging enabled, log will be saved as /home/jdisnard/MakeMKV_log.txt
Using direct disc access mode
Loaded content hash table, will verify integrity of M2TS files.
This disc requires Java runtime (JRE), but none was found. Certain functions will fail, please install Java. See http://www.makemkv.com/bdjava/ for details.
```

* The correct SDK extension is probably here:
https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk8/tree/branch/21.08

Signed-off-by: Jon Disnard <jdisnard@redhat.com>