### PR TITLE
removed host filesystem access, replaced with sane locations

### DIFF
--- a/com.makemkv.MakeMKV.yaml
+++ b/com.makemkv.MakeMKV.yaml
@@ -5,7 +5,12 @@ sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk17
 finish-args:
-  - --filesystem=host
+  - --filesystem=home
+  - --filesystem=/media
+  - --filesystem=/mnt
+  - --filesystem=/run/media
+  - --filesystem=/var/run/media
+  - --filesystem=/var/mnt
   # X11 access
   - --socket=x11
   - --share=ipc


### PR DESCRIPTION
especially as its proprietary, it should not have host access

This is not hardening, its simply all the locations media file actually are at. Its a start for easier hardening also for users

  - --filesystem=home
  - --filesystem=/media
  - --filesystem=/mnt
  - --filesystem=/run/media
  - --filesystem=/var/run/media
  - --filesystem=/var/mnt