### PR TITLE
Add Wayland socket permission

### DIFF
--- a/com.makemkv.MakeMKV.yaml
+++ b/com.makemkv.MakeMKV.yaml
@@ -6,8 +6,10 @@ sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk8
 finish-args:
   - --filesystem=host
+  # Wayland access
+  - --socket=wayland
   # X11 access
-  - --socket=x11
+  - --socket=fallback-x11
   - --share=ipc
   # Network access
   - --share=network


### PR DESCRIPTION
It appears that MakeMKV comes with a native Wayland backend. Like most Qt applications, it will automatically use Wayland instead of Xwayland if possible:

```
$ flatpak run --socket=wayland com.makemkv.MakeMKV
```