### PR TITLE
Restrict default filesystem access to ~/.MakeMKV and ~/Videos

### DIFF
--- a/com.makemkv.MakeMKV.yaml
+++ b/com.makemkv.MakeMKV.yaml
@@ -5,7 +5,8 @@ sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk8
 finish-args:
-  - --filesystem=host
+  - --filesystem=~/.MakeMKV:create
+  - --filesystem=xdg-videos
   # Wayland access
   - --socket=wayland
   # X11 access


### PR DESCRIPTION
Qt can use the file picker portal to gain write access to specific directories from within the sandbox.

This seems to work for scenarios like:

*  setting alternative data directories
*  writing files to external drives