### PR TITLE
Fix: Downgrade ffmpeg to 4.4.5 to make the flac profile work again

### DIFF
--- a/com.makemkv.MakeMKV.yaml
+++ b/com.makemkv.MakeMKV.yaml
@@ -50,8 +50,8 @@ modules:
       - /share/ffmpeg/examples
     sources:
       - type: archive
-        url: https://ffmpeg.org/releases/ffmpeg-7.0.2.tar.xz
-        sha256: 8646515b638a3ad303e23af6a3587734447cb8fc0a0c064ecdb8e95c4fd8b389
+        url: https://ffmpeg.org/releases/ffmpeg-4.4.5.tar.xz
+        sha256: f9514e0d3515aee5a271283df71636e1d1ff7274b15853bcd84e144be416ab07
         x-checker-data:
           type: anitya
           project-id: 5405


### PR DESCRIPTION
MakeMKV seems to have a problem with newer ffmpeg versions when trying to use the flac profile. (see #71 )
This downgrades ffmpeg to the version 4.4.4, which is also used in some other flatpaks, allowing to dump files with the flac profile again.

Fixes #71