### PR TITLE
Change .MakeMKV from filesystem to persist

### DIFF
--- a/com.makemkv.MakeMKV.yaml
+++ b/com.makemkv.MakeMKV.yaml
@@ -5,7 +5,7 @@ sdk: org.kde.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.openjdk8
 finish-args:
-  - --filesystem=~/.MakeMKV:create
+  - --persist=.MakeMKV
   - --filesystem=xdg-videos
   # Wayland access
   - --socket=wayland


### PR DESCRIPTION
Moves the internal settings to the proper path (~/.var/app/com.makemkv.MakeMKV/.MakeMKV) as MakeMKV does not follow the XDG Base Directory specification.